### PR TITLE
Fix Pathname#empty? example in Ruby 2.4.0 post

### DIFF
--- a/_posts/2016-12-25-ruby-2-4-features.md
+++ b/_posts/2016-12-25-ruby-2-4-features.md
@@ -219,9 +219,9 @@ __`Enumerable#sum`__
 The `#empty?` method was added to `Dir`, `File` and `Pathname`.
 
 {% highlight ruby %}
-Dir.empty?('path/to/some/dir')    #=> true
-File.empty?('path/to/some/file')  #=> true
-Pathname.empty?('file-or-dir')    #=> true
+Dir.empty?('path/to/some/dir')     #=> true
+File.empty?('path/to/some/file')   #=> true
+Pathname.new('file-or-dir').empty? #=> true
 {% endhighlight %}
 
 ### Language features


### PR DESCRIPTION
`Pathname#empty?` is an instance method, not a class method like `Dir.empty?` or `File.empty?`