### PR TITLE
Lazy-load Giscus comments near the comments section

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,6 +1,12 @@
 <div id="comments"></div>
 <script>
+  var comments = document.getElementById("comments");
+  var scriptLoaded = false;
+
   function loadGiscusComments() {
+      if (scriptLoaded) return;
+
+      scriptLoaded = true;
       var script = document.createElement('script');
       script.src = "https://giscus.app/client.js";
       script.async = true;
@@ -19,17 +25,29 @@
       script.setAttribute("data-lang", "en");
       script.setAttribute("data-loading", "lazy");
 
-      document.getElementById("comments").appendChild(script);
+      comments.appendChild(script);
   }
 
-  var scriptLoaded = false;
-  function loadCommentScriptOnce() {
-    if (!scriptLoaded) {
-      loadGiscusComments();
-      scriptLoaded = true;
+  if ("IntersectionObserver" in window) {
+    var commentsObserver = new IntersectionObserver(function(entries) {
+      if (entries.some(function(entry) { return entry.isIntersecting; })) {
+        loadGiscusComments();
+        commentsObserver.disconnect();
+      }
+    }, { rootMargin: "800px 0px" });
+
+    commentsObserver.observe(comments);
+  } else {
+    function loadCommentsWhenNearViewport() {
+      var commentsTop = comments.getBoundingClientRect().top;
+
+      if (commentsTop <= window.innerHeight + 800) {
+        loadGiscusComments();
+        window.removeEventListener("scroll", loadCommentsWhenNearViewport);
+      }
     }
-  }
 
-  setTimeout(loadCommentScriptOnce, 5000);
-  window.addEventListener("scroll", loadCommentScriptOnce);
+    window.addEventListener("scroll", loadCommentsWhenNearViewport, { passive: true });
+    loadCommentsWhenNearViewport();
+  }
 </script>


### PR DESCRIPTION
## What changed

- Removed the fixed five-second Giscus load.
- Load Giscus when the comments container is within 800px of the viewport using `IntersectionObserver`.
- Added a one-time scroll-position fallback for browsers without `IntersectionObserver`.
- Kept the existing Giscus configuration and one-script guard intact.

## Why

The comments widget was being requested after a timer even when a reader never reached the bottom of a post. Loading it based on proximity to the comments section avoids that unnecessary request while preserving the existing comments experience.

