### PR TITLE
Fix mismatched heading closing tags

### DIFF
--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class='post page'>
-  <h1 class='title'>{{ page.title }}</h2>
+  <h1 class='title'>{{ page.title }}</h1>
   <p><small><i>Showing posts tagged with #{{ page.category }}</i></small></p>
 </div>
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,7 +8,7 @@ layout: default
       <a href="/notes/">Notes</a> /
     {% endif %}
     {{ page.title }}
-    </h2>
+    </h1>
 
   <div class='content'>
   {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class='post'>
-  <h1 class='title'>{{ page.title }}</h2>
+  <h1 class='title'>{{ page.title }}</h1>
   <p class='meta'>{{ page.date | date_to_string }}</p>
 
   <div class='content'>


### PR DESCRIPTION
## What changed

Corrected the closing tags for the `h1` page-title elements in:

- `_layouts/post.html`
- `_layouts/page.html`
- `_layouts/category.html`

## Why

Each layout opened an `h1` but closed it as `h2`, producing malformed heading markup in generated pages and contributing to heading-order accessibility issues.

## Validation

- Focused layout check passed: all three files contain no `</h2>` title closer and do contain an `</h1>` closer.
- `git diff --check` passed.
- The branch is based on the latest `master`.
- Full Jekyll build remains unavailable because the repository's legacy pinned dependencies do not compile on the installed Ruby 4.0.
