### PR TITLE
Improve homepage heading semantics

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -63,7 +63,7 @@ h1, h2, h3, h4, h5, h6, strong { color: var(--bold-text-color); }
   margin: 50px 0 0 0;
   font-family: Georgia, serif;
 }
-.about-me h2 {
+.about-me h1 {
   font-size: 2em;
   font-weight: bolder;
   margin: 0 0 30px 0;
@@ -94,6 +94,7 @@ h1, h2, h3, h4, h5, h6, strong { color: var(--bold-text-color); }
 
 .site .posts .post-listing { line-height: 2em; }
 .site .posts .post-listing .year { margin: 30px 0; }
+.site .posts .post-listing .year h2 { font-size: 1.17em; }
 .site .posts .post-listing ul { padding: 20px 0; }
 .site .posts .post-listing ul li { list-style-type: none; }
 .site .posts .published-on {

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ balloon_css: true
 ---
 
 <div class="about-me">
-  <h2>Hi, I'm Nithin.</h2>
+  <h1>Hi, I'm Nithin.</h1>
 
   <p class="description">
     I am a software developer based in Ottawa, Canada.
@@ -69,7 +69,7 @@ balloon_css: true
 
     {% for year in years %}
       <div class="year">
-        <h3>{{ year.name }}</h3>
+        <h2>{{ year.name }}</h2>
 
         <ul>
           {% for post in year.items %}


### PR DESCRIPTION
## What changed

- Changed the homepage introduction from `h2` to `h1`.
- Changed each homepage year heading from `h3` to `h2`.
- Updated the corresponding CSS selectors and preserved the existing visual sizing.

## Why

The homepage should have a clear primary heading followed by year-level section headings. This improves document structure and accessibility without changing the page's appearance.

## Validation

- Focused homepage heading check passed.
- `git diff --check` passed.
- Branch is based on the latest `master`, including the merged heading-tag fix.
