### PR TITLE
Load Amazon localizer only for Amazon links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,7 +57,10 @@
     </div>
   </div> <!-- /container -->
   {% include footer-analytics.html %}
+  {%- assign rendered_content = content | downcase -%}
+  {%- if rendered_content contains 'href="https://www.amazon.' or rendered_content contains 'href="http://www.amazon.' or rendered_content contains 'href="https://amazon.' or rendered_content contains 'href="http://amazon.' or rendered_content contains 'href="https://amzn.to/' or rendered_content contains 'href="http://amzn.to/' -%}
   <script src="/js/amazon_localize.js" defer></script>
+  {%- endif -%}
 </body>
 
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,7 +58,7 @@
   </div> <!-- /container -->
   {% include footer-analytics.html %}
   {%- assign rendered_content = content | downcase -%}
-  {%- if rendered_content contains 'href="https://www.amazon.' or rendered_content contains 'href="http://www.amazon.' or rendered_content contains 'href="https://amazon.' or rendered_content contains 'href="http://amazon.' or rendered_content contains 'href="https://amzn.to/' or rendered_content contains 'href="http://amzn.to/' -%}
+  {%- if rendered_content contains '://www.amazon.com/' or rendered_content contains '://amazon.com/' -%}
   <script src="/js/amazon_localize.js" defer></script>
   {%- endif -%}
 </body>


### PR DESCRIPTION
## What

- Gate `amazon_localize.js` behind a rendered-content check in the shared layout.
- Load it only when the page contains a direct `amazon.com` link, which is what the script can rewrite.
- Avoid loading it for unrelated AWS links, other Amazon domains, or `amzn.to` shortlinks.

## Why

The shared layout previously loaded the script on every page, even though most pages don't contain a localizable Amazon link.

## Testing

- Ran a full production Jekyll build with Ruby 3.4.5 and Jekyll 3.10.0.
- Checked that the script is included on `/uses/` and an Amazon-linked books post.
- Checked that it is omitted from the homepage, an `amzn.to`-only post, and the AWS-forum post.
- Confirmed it is included in 8 of 296 generated HTML files.
- Ran `git diff --check`.
