### PR TITLE
Load Balloon CSS without blocking rendering

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,11 @@
   <link rel="stylesheet" href="/css/syntax.css">
   {%- endif -%}
   {%- if page.balloon_css -%}
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/balloon-css/1.2.0/balloon.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/balloon-css/1.2.0/balloon.min.css"
+    media="print" onload="this.media='all'">
+  <noscript>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/balloon-css/1.2.0/balloon.min.css">
+  </noscript>
   {%- endif -%}
 
   {% include analytics.html %}


### PR DESCRIPTION
## What

Load the homepage's Balloon CSS with `media="print"`, then switch it to `all` after the stylesheet finishes loading. A `noscript` fallback keeps the tooltips styled when JavaScript is disabled.

## Why

Balloon CSS was the slowest render-blocking request in the latest mobile PageSpeed run. The homepage still keeps the existing Balloon tooltips, but the stylesheet no longer delays the first render.

## Testing

- Ran a full Jekyll build
- Verified the generated homepage includes the non-blocking attributes and `noscript` fallback
- Verified post pages do not load Balloon CSS
- Ran `git diff --check`
