### PR TITLE
Remove duplicate Cloudflare beacon

### DIFF
--- a/_includes/footer-analytics.html
+++ b/_includes/footer-analytics.html
@@ -1,3 +1,0 @@
-{% if jekyll.environment != "development" %}
-<script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "e8ac7c27f6114c9ea3848378b7e5e686"}'></script>
-{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,7 +63,6 @@
       <a href="https://github.com/nithinbekal/nithinbekal.github.io/">Get this theme here</a>.
     </div>
   </div> <!-- /container -->
-  {% include footer-analytics.html %}
   {%- if rendered_content contains '://www.amazon.com/' or rendered_content contains '://amazon.com/' -%}
   <script src="/js/amazon_localize.js" defer></script>
   {%- endif -%}

--- a/_layouts/revealjs.html
+++ b/_layouts/revealjs.html
@@ -80,6 +80,5 @@
         ]
       });
     </script>
-    {% include footer-analytics.html %}
   </body>
 </html>


### PR DESCRIPTION
## What

Remove the manually embedded Cloudflare Web Analytics beacon from the default and Reveal.js layouts, and delete the unused include.

## Why

Cloudflare already injects its own beacon at the edge. Keeping the repository-managed beacon caused each page to load two beacon scripts with different analytics tokens.

## Testing

- `git diff --check`
- Confirmed there are no remaining references to the removed include or manual token
- Full Jekyll build could not run locally because the locked GitHub Pages dependencies are not installed and the local fallback dependency fails to compile
